### PR TITLE
Ajoute l'email de la mairie au modèle de création de "submission"

### DIFF
--- a/lib/publication/models.js
+++ b/lib/publication/models.js
@@ -10,6 +10,24 @@ const mongo = require('../util/mongo')
 const gzip = promisify(zlib.gzip)
 const communesIndex = keyBy(communes.filter(c => c.type === 'commune-actuelle'), 'code')
 
+const API_ETABLISSEMENTS_PUBLICS = 'https://etablissements-publics.api.gouv.fr/v3'
+
+const getCommuneEmail = async function (codeCommune) {
+  let email
+
+  try {
+    const response = await got(`${API_ETABLISSEMENTS_PUBLICS}/communes/${codeCommune}/mairie`, {json: true})
+    const mairie = response.body.features[0]
+    if (mairie) {
+      email = mairie.email
+    }
+  } catch (error) {
+
+  }
+
+  return email
+}
+
 async function createSubmission({url}) {
   const submission = {url}
 
@@ -29,12 +47,14 @@ async function createSubmission({url}) {
 
   const now = new Date()
   const _id = new mongo.ObjectID()
+  const commune = pick(communesIndex[communes[0]], 'code', 'nom')
 
   Object.assign(submission, {
     _id,
     url,
+    commune,
     status: 'created',
-    commune: pick(communesIndex[communes[0]], 'code', 'nom'),
+    email: await getCommuneEmail(commune.code),
     authenticationUrl: `${process.env.BACKEND_API_URL}/publication/submissions/${_id}/authenticate`,
     data: await gzip(data),
     _created: now,

--- a/lib/publication/models.js
+++ b/lib/publication/models.js
@@ -13,19 +13,13 @@ const communesIndex = keyBy(communes.filter(c => c.type === 'commune-actuelle'),
 const API_ETABLISSEMENTS_PUBLICS = process.env.API_ETABLISSEMENTS_PUBLICS || 'https://etablissements-publics.api.gouv.fr/v3'
 
 const getCommuneEmail = async function (codeCommune) {
-  let email
-
   try {
     const response = await got(`${API_ETABLISSEMENTS_PUBLICS}/communes/${codeCommune}/mairie`, {responseType: 'json'})
     const mairie = response.body.features[0]
-    if (mairie) {
-      email = mairie.properties.email
-    }
+    return mairie.properties.email
   } catch (error) {
-
+    console.log(`Une erreur s’est produite lors de la récupération de l’adresse email de la mairie : ${error}`)
   }
-
-  return email
 }
 
 async function createSubmission({url}) {
@@ -48,13 +42,13 @@ async function createSubmission({url}) {
   const now = new Date()
   const _id = new mongo.ObjectID()
   const commune = pick(communesIndex[communes[0]], 'code', 'nom')
+  commune.email = await getCommuneEmail(commune.code)
 
   Object.assign(submission, {
     _id,
     url,
     commune,
     status: 'created',
-    email: await getCommuneEmail(commune.code),
     authenticationUrl: `${process.env.BACKEND_API_URL}/publication/submissions/${_id}/authenticate`,
     data: await gzip(data),
     _created: now,

--- a/lib/publication/models.js
+++ b/lib/publication/models.js
@@ -10,7 +10,7 @@ const mongo = require('../util/mongo')
 const gzip = promisify(zlib.gzip)
 const communesIndex = keyBy(communes.filter(c => c.type === 'commune-actuelle'), 'code')
 
-const API_ETABLISSEMENTS_PUBLICS = 'https://etablissements-publics.api.gouv.fr/v3'
+const API_ETABLISSEMENTS_PUBLICS = process.env.API_ETABLISSEMENTS_PUBLICS || 'https://etablissements-publics.api.gouv.fr/v3'
 
 const getCommuneEmail = async function (codeCommune) {
   let email

--- a/lib/publication/models.js
+++ b/lib/publication/models.js
@@ -16,10 +16,10 @@ const getCommuneEmail = async function (codeCommune) {
   let email
 
   try {
-    const response = await got(`${API_ETABLISSEMENTS_PUBLICS}/communes/${codeCommune}/mairie`, {json: true})
+    const response = await got(`${API_ETABLISSEMENTS_PUBLICS}/communes/${codeCommune}/mairie`, {responseType: 'json'})
     const mairie = response.body.features[0]
     if (mairie) {
-      email = mairie.email
+      email = mairie.properties.email
     }
   } catch (error) {
 


### PR DESCRIPTION
L'ajout de l'email de la mairie a pour objectif de permettre une identification alternative à FranceConnect lors de la publication d'une Base Adresse Locale.